### PR TITLE
Made S3BotoStorage deconstructible so that Django can migrate it.

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -193,7 +193,7 @@ class S3BotoStorageFile(File):
                 self._multipart.cancel_upload()
         self.key.close()
 
-
+@deconstructible
 class S3BotoStorage(Storage):
     """
     Amazon Simple Storage Service using Boto


### PR DESCRIPTION
Without this, Django 1.7 migrations fail with 
`ValueError: Cannot serialize: <storages.backends.s3boto.S3BotoStorage object at 0x1050a1358>
There are some values Django cannot serialize into migration files.
`
